### PR TITLE
Updated udev rules to current format.

### DIFF
--- a/99-x52pro.rules
+++ b/99-x52pro.rules
@@ -1,14 +1,9 @@
-ACTION!="add", GOTO="x52pro_rules_end"
-SUBSYSTEM!="usb_device", GOTO="x52pro_rules_end"
-
 #X52 Flight System
-SYSFS{idVendor}=="06a3", SYSFS{idProduct}=="0255", GROUP="plugdev", MODE="660"
-SYSFS{idVendor}=="06a3", SYSFS{idProduct}=="075c", GROUP="plugdev", MODE="660"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="0255", MODE="660", GROUP="plugdev"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="075c", MODE="660", GROUP="plugdev"
 
 #X52 Pro Flight System
-SYSFS{idVendor}=="06a3", SYSFS{idProduct}=="0762", GROUP="plugdev", MODE="660"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="0762", MODE="660", GROUP="plugdev"
 
 #Pro Flight Yoke System
-SYSFS{idVendor}=="06a3", SYSFS{idProduct}=="0bac", GROUP="plugdev", MODE="660"
-
-LABEL="x52pro_rules_end"
+ACTION=="add", SUBSYSTEM=="input", ATTR{idVendor}=="06a3", ATTR{idProduct}=="0bac", MODE="660", GROUP="plugdev"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install:
 	ln -sf libx52pro.so.0 $(DESTDIR)/usr/lib/libx52pro.so
 	install -D -m 644 x52output.c $(DESTDIR)/usr/share/doc/libx52pro0/examples/x52output.c
 	install -D x52output $(DESTDIR)/usr/bin/x52output
-	install -D -m 644 99-x52pro.rules $(DESTDIR)/etc/udev/rules.d/99-x52pro.rules
+	install -D -m 644 99-x52pro.rules $(DESTDIR)/lib/udev/rules.d/99-x52pro.rules
 	install -D -m 644 x52output.1.gz $(DESTDIR)/usr/share/man/man1/x52output.1.gz
 
 x52output: x52output.o $(X52LIB) -lusb


### PR DESCRIPTION
The package uses an obsolete udev rules format (with SYSFS==), making it useless.  Adjust install path to the current location.

Patch from Debian and Alex Volkov.

Solve https://bugs.debian.org/734067.