### PR TITLE
Adjusted build flags to make it easier to enable hardened build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # defaults
 CC ?= gcc
+CPPFLAGS ?=
 CFLAGS ?= -Wall -Wextra -Wpedantic -std=c99 -g -O0
 LDFLAGS ?= -g
 INSTALL ?= install
@@ -24,7 +25,7 @@ x52pro.o_CFLAGS := $(USBINC) -fPIC -D_REENTRANT
 x52output.o_CFLAGS := -I.
 
 %.o: %.c
-	$(CC) $(CFLAGS) $($@_CFLAGS) -c -o $@ $<
+	$(CC) ${CPPFLAGS} $(CFLAGS) $($@_CFLAGS) -c -o $@ $<
 
 clean:
 	-$(RM) *.so* *.o x52output x52output.1.gz


### PR DESCRIPTION
Make sure build flags passed on the command line are used during build, not replaced by settings in the Makefile.