### PR TITLE
Grant device access for console users instead of plugdev members.

### DIFF
--- a/99-x52pro.rules
+++ b/99-x52pro.rules
@@ -1,9 +1,9 @@
 #X52 Flight System
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="0255", MODE="660", GROUP="plugdev"
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="075c", MODE="660", GROUP="plugdev"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="0255", TAG+="uaccess"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="075c", TAG+="uaccess"
 
 #X52 Pro Flight System
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="0762", MODE="660", GROUP="plugdev"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="06a3", ATTRS{idProduct}=="0762", TAG+="uaccess"
 
 #Pro Flight Yoke System
-ACTION=="add", SUBSYSTEM=="input", ATTR{idVendor}=="06a3", ATTR{idProduct}=="0bac", MODE="660", GROUP="plugdev"
+ACTION=="add", SUBSYSTEM=="input", ATTR{idVendor}=="06a3", ATTR{idProduct}=="0bac", TAG+="uaccess"


### PR DESCRIPTION
Instead of having to add people to the plugdev group to talk to the device, allow every locally logged in user acces using the uaccess udev tag.

It might be an alternative to keep the plugdev setup for backward compatibility and to be able to grant access to background processes without a locally logged in user.