### PR TITLE
Provide Appstream metadata XML with hardware mapping.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ install:
 	$(INSTALL_DATA) -D x52output.1.gz $(DESTDIR)/usr/share/man/man1/x52output.1.gz
 	$(INSTALL) -D x52output $(DESTDIR)/usr/bin/x52output
 	$(INSTALL_DATA) -D 60-x52pro.rules $(DESTDIR)/lib/udev/rules.d/60-x52pro.rules
+	$(INSTALL_DATA) -D at.hasenleithner.plasma.x52pro.metainfo.xml $(DESTDIR)/usr/share/metainfo/at.hasenleithner.plasma.x52pro.metainfo.xml
 
 x52output: x52output.o $(X52LIB)
 x52output.1.gz: x52output.1

--- a/at.hasenleithner.plasma.x52pro.metainfo.xml
+++ b/at.hasenleithner.plasma.x52pro.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+  <id>at.hasenleithner.plasma.x52pro</id>
+  <metadata_license>MIT</metadata_license>
+  <name>libx52pro0</name>
+  <summary>MFD and LED library for Saitek X52pro joysticks</summary>
+  <description>
+    <p>The library libx52pro is designed to support MFD and LED found
+    on Saitek X52 and X52pro joystick.  Library does not deal with the
+    HID part of the joystick since this feature is already fully
+    supported by the Linux kernel 2.6.x.  This package include the
+    x52output utility.</p>
+  </description>
+  <url type="homepage">https://github.com/seesturm/x52lib/</url>
+  <categories>
+    <category>System</category>
+  </categories>
+  <provides>
+    <modalias>usb:v06A3p0255d*</modalias>
+    <modalias>usb:v06A3p075Cd*</modalias>
+    <modalias>usb:v06A3p0762d*</modalias>
+    <modalias>usb:v06A3p0BACd*</modalias>
+  </provides>
+</component>


### PR DESCRIPTION
This ensure tools looking up hardware IDs are told this package is useful for the given USB IDs listed.